### PR TITLE
Using `prefix` instead of `directory` in GCS-Read

### DIFF
--- a/gcs-read.js
+++ b/gcs-read.js
@@ -132,7 +132,7 @@ module.exports = function(RED) {
 
             const bucket = storage.bucket(bucketName);
             const getFilesOptions = {
-                directory: fileName
+                prefix: fileName
             };
             const [files] = await bucket.getFiles(getFilesOptions);
             const retArray = [];


### PR DESCRIPTION
Currently, the "directory" option is used for listing files. However, since my files are timestamps, I'd like to be able to use the "prefix" option instead. They work the same way, except the "directory" option only matches folder names.