### PR TITLE
Add new DNS "change create" and "records list" nodes

### DIFF
--- a/dns-change-create.html
+++ b/dns-change-create.html
@@ -1,0 +1,87 @@
+<!--
+Copyright 2020 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script type="text/x-red" data-template-name="google-cloud-dns-change-create">
+    <div class="form-row">
+        <label for="node-input-account"><i class="fa fa-user"></i> Credentials</label>
+        <input type="text" id="node-input-account">        
+    </div>
+    <div class="form-row">
+        <label for="node-input-keyFilename"><i class="fa fa-user"></i> Key File</label>
+        <input type="text" id="node-input-keyFilename">
+    </div>
+    <div class="form-row">
+        <label for="node-input-projectId"><i class="fa fa-cloud"></i> Project</label>
+        <input type="text" id="node-input-projectId">
+    </div>
+    <div class="form-row">
+        <label for="node-input-managedZone"><i class="fa fa-search"></i> Managed Zone</label>
+        <input type="text" id="node-input-managedZone">
+    </div>
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name">
+    </div>       
+</script>
+
+<script type="text/x-red" data-help-name="google-cloud-dns-change-create">
+    <p>Atomically update a ResourceRecordSet collection.</p>
+    <h3>Inputs</h3>
+    <dl class="message-properties">
+        <dt>msg.additions
+            <span class="property-type">array</span>
+        </dt>
+        <dd>Which ResourceRecordSets to add.</dd>
+    </dl>
+    <dl class="message-properties">
+        <dt>msg.deletions
+            <span class="property-type">array</span>
+        </dt>
+        <dd>Which ResourceRecordSets to remove.</dd>
+    </dl>
+    <h3>Details</h3>
+    <p>
+    The DNS Change Create node wraps the <a href="https://cloud.google.com/dns/docs/reference/v1/changes/create">Change Create</a> request.
+    </p>
+    <p>
+    When executed, the arrays of <a href="https://cloud.google.com/dns/docs/reference/v1/resourceRecordSets">ResourceRecordSets</a>
+    in <code>msg.additions</code> and <code>msg.deletions</code> will be added or deleted respectively.
+    </p>
+    <p>
+    On return, the raw response from the Javascript client library will be saved in <code>msg.payload</code>.
+    </p>
+</script>
+
+<script type="text/javascript">
+RED.nodes.registerType("google-cloud-dns-change-create", {
+    category: "GCP",
+    defaults: {
+        account: { type: "google-cloud-credentials", required: false },
+        keyFilename: { value: "", required: false },
+        projectId: { value: "", required: false},
+        managedZone: { value: "", required: false },
+        name: { value: "", required: false }
+    },
+    inputs: 1,
+    outputs: 1,
+    align: "left",
+    color: "#3FADB5",
+    label: function () {
+        return this.name || "dns-change-create";
+    },
+    paletteLabel: "dns-change-create"
+});
+</script>

--- a/dns-change-create.js
+++ b/dns-change-create.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This node provides DLP processing.  We will assume that msg.payload
+ * contains the original data that may contain sensistive data.
+ * 
+ * The configuration for the node includes:
+ *
+ */
+/* jshint esversion: 8 */
+module.exports = function(RED) {
+    "use strict";
+    const NODE_TYPE = "google-cloud-dns-change-create";
+    const {DNS, Record} = require('@google-cloud/dns');
+
+    function DnsChangeCreateNode(config) {
+        RED.nodes.createNode(this, config);
+        const node = this;
+
+        let dnsOptions = {
+            projectId: config.projectId,
+        };
+        if (config.account) {
+            dnsOptions.credentials = JSON.parse(RED.nodes.getCredentials(node).account);
+        } else if (config.keyFilename) {
+            dnsOptions.keyFilename = config.keyFilename;
+        }
+        const dns = new DNS(dnsOptions);
+        const zone = dns.zone(config.managedZone);
+
+        // Converts an (easy to construct in node-red) object representation of
+        // https://cloud.google.com/dns/docs/reference/v1/resourceRecordSets#resource
+        // into a Record from the DNS library.
+        function toRecord(resourceRecordSet) {
+            return new Record(
+                config.managedZone,
+                resourceRecordSet.type,
+                {
+                    name: resourceRecordSet.name,
+                    data: resourceRecordSet.rrdatas,
+                    ttl: resourceRecordSet.ttl,
+                    type: resourceRecordSet.type || "",
+                    signatureRrdatas: resourceRecordSet.signatureRrdatas || [],
+                });
+        }
+
+        // Called when a message arrives at the node.
+        node.on("input", async function(msg) {
+            try {
+                msg.payload = await zone.createChange({
+                    add: (msg.additions || []).map(toRecord),
+                    delete: (msg.deletions || []).map(toRecord),
+                });
+            } catch (exp) {
+                node.error(exp);
+                msg.error = exp;
+                return;
+            }
+            node.send(msg);
+        });
+    }
+
+    RED.nodes.registerType(NODE_TYPE, DnsChangeCreateNode);
+};

--- a/dns-records-list.html
+++ b/dns-records-list.html
@@ -1,0 +1,96 @@
+<!--
+Copyright 2020 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script type="text/x-red" data-template-name="google-cloud-dns-records-list">
+    <div class="form-row">
+        <label for="node-input-account"><i class="fa fa-user"></i> Credentials</label>
+        <input type="text" id="node-input-account">        
+    </div>
+    <div class="form-row">
+        <label for="node-input-keyFilename"><i class="fa fa-user"></i> Key File</label>
+        <input type="text" id="node-input-keyFilename">
+    </div>
+    <div class="form-row">
+        <label for="node-input-projectId"><i class="fa fa-cloud"></i> Project</label>
+        <input type="text" id="node-input-projectId">
+    </div>
+    <div class="form-row">
+        <label for="node-input-managedZone"><i class="fa fa-search"></i> Managed Zone</label>
+        <input type="text" id="node-input-managedZone">
+    </div>
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name">
+    </div>       
+</script>
+
+<script type="text/x-red" data-help-name="google-cloud-dns-records-list">
+    <p>Enumerate ResourceRecordSets that have been created but not yet deleted.</p>
+    <h3>Inputs</h3>
+    <dl class="message-properties">
+        <dt>msg.maxResults
+            <span class="property-type">int</span>
+        </dt>
+        <dd>Optional. Maximum number of results to be returned.</dd>
+    </dl>
+    <dl class="message-properties">
+        <dt>msg.name
+            <span class="property-type">array</span>
+        </dt>
+        <dd>Restricts the list to return only records with this fully qualified domain name.</dd>
+    </dl>
+    <dl class="message-properties">
+        <dt>msg.pageToken
+            <span class="property-type">array</span>
+        </dt>
+        <dd>Optional. A tag returned by a previous list request that was truncated. Use this parameter to continue a previous list request.</dd>
+    </dl>
+    <dl class="message-properties">
+        <dt>msg.type
+            <span class="property-type">array</span>
+        </dt>
+        <dd>Restricts the list to return only records of this type. If present, the <code>name</code> parameter must also be present.</dd>
+    </dl>
+    <h3>Details</h3>
+    <p>
+    The DNS Record List node wraps the <a href="https://cloud.google.com/dns/docs/reference/v1/resourceRecordSets/list">ResourceRecordSets List</a> request.
+    </p>
+    <p>
+    On return, an array of <a href="https://cloud.google.com/dns/docs/reference/v1/resourceRecordSets#resource">ResourceRecordSets</a>
+    will be saved in <code>msg.payload</code>, and the raw response from the Javascript client library will be stored in <code>msg.response</code>.
+    </p>
+</script>
+
+<script type="text/javascript">
+RED.nodes.registerType("google-cloud-dns-records-list", {
+    category: "GCP",
+    defaults: {
+        account: { type: "google-cloud-credentials", required: false },
+        keyFilename: { value: "", required: false },
+        projectId: { value: "", required: false},
+        managedZone: { value: "", required: false },
+        name: { value: "", required: false }
+    },
+    inputs: 1,
+    outputs: 1,
+    align: "left",
+    color: "#3FADB5",
+    label: function () {
+        return this.name || "dns-records-list";
+    },
+    paletteLabel: "dns-records-list"
+});
+</script>

--- a/dns-records-list.js
+++ b/dns-records-list.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This node provides DLP processing.  We will assume that msg.payload
+ * contains the original data that may contain sensistive data.
+ * 
+ * The configuration for the node includes:
+ *
+ */
+/* jshint esversion: 8 */
+module.exports = function(RED) {
+    "use strict";
+    const NODE_TYPE = "google-cloud-dns-records-list";
+    const {DNS} = require('@google-cloud/dns');
+
+    function DnsRecordsListNode(config) {
+        RED.nodes.createNode(this, config);
+        const node = this;
+
+        let dnsOptions = {
+            projectId: config.projectId,
+        };
+        if (config.account) {
+            dnsOptions.credentials = JSON.parse(RED.nodes.getCredentials(node).account);
+        } else if (config.keyFilename) {
+            dnsOptions.keyFilename = config.keyFilename;
+        }
+        const dns = new DNS(dnsOptions);
+        const zone = dns.zone(config.managedZone);
+
+        // Converts a Record from the DNS library into a
+        // https://cloud.google.com/dns/docs/reference/v1/resourceRecordSets#resource.
+        function fromRecord(record) {
+            return {
+                "kind": "dns#resourceRecordSet",
+                "name": record.name,
+                "type": record.type,
+                "ttl": record.ttl,
+                "rrdatas": record.data,
+                "signatureRrdatas": record.signatureRrdatas,
+            };
+        }
+
+        // Called when a message arrives at the node.
+        node.on("input", async function(msg) {
+            try {
+                msg.response = await zone.getRecords({
+                    maxResults: msg.maxResults,
+                    name: msg.name,
+                    pageToken: msg.pageToken,
+                    type: msg.type,
+                });
+            } catch (exp) {
+                node.error(exp);
+                msg.error = exp;
+                return;
+            }
+            const [records,] = msg.response;
+            msg.payload = records.map(fromRecord);
+            node.send(msg);
+        });
+    }
+
+    RED.nodes.registerType(NODE_TYPE, DnsRecordsListNode);
+};

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "@google-cloud/automl": "^2.0.0",
         "@google-cloud/bigquery": "latest",
         "@google-cloud/dlp": "latest",
+        "@google-cloud/dns": "latest",
         "@google-cloud/firestore": "latest",
         "@google-cloud/iot": "latest",
         "@google-cloud/language": "latest",
@@ -42,6 +43,8 @@
     "node-red": {
         "nodes": {
             "google-cloud-credentials": "credentials.js",
+            "google-cloud-dns-change-create": "dns-change-create.js",
+            "google-cloud-dns-records-list": "dns-records-list.js",
             "google-cloud-private-key": "private-key.js",
             "google-cloud-pubsub in": "pubsub-in.js",
             "google-cloud-pubsub out": "pubsub-out.js",


### PR DESCRIPTION
These nodes essentially expose [this call](https://cloud.google.com/dns/docs/reference/v1/changes/create) to "set" DNS records and [this call](https://cloud.google.com/dns/docs/reference/v1/resourceRecordSets/list) to "read" DNS records.

Notes:
- I've only covered this limited subset of the full DNS API because they're probably the most frequently used bits, and selfishly because they're the only bits I need for my personal project :)
- The other nodes have special icons - I've omitted icons for these because I can't find a similarly-styled icon for GCP DNS.
- The API for these nodes is a bit weird: having the node inputs and outputs be the same as the underlying DNS Javascript API would be easy to write, but it's hard for users to find that API (I had to read [the source](https://github.com/googleapis/nodejs-dns) to work out what the objects are), and the use of `toJSON` overrides in that library means users would essentially have to use JS function nodes to include the library and create those objects before passing them in, rather than just construct JSON objects with the same structure which is pretty conventional for node-red.
  
  The REST API has some nice JSON-compatible parameters/responses which makes it easier to use in node-red, and is [very easily discoverable](https://cloud.google.com/dns/docs/reference/v1/changes/create). But then we need to translate between REST- and JS-style values in the nodes in order to use the client library :(

  This implementation finds a middle ground by translating the "necessary" (all input parameters) and "useful" stuff (the records returned by the Record List node) and exposing the "raw" JS-api responses in `msg.response`. It's not very neat, but it's easy to use. Open to suggestions on changes to this approach.
- This is the first JS I've written, it's mostly tweaks on existing files in this repo, so please recommend improvements if you find any.