### PR TITLE
Improve reading speed of gcs-read

### DIFF
--- a/gcs-read.js
+++ b/gcs-read.js
@@ -98,6 +98,11 @@ module.exports = function(RED) {
 
             const readStream = file.createReadStream();
 
+            // Pre-allocate the download buffer
+            const fileSize = parseInt(msg.metadata.size, 10)
+            msg.payload = Buffer.allocUnsafe(fileSize)
+            let pos = 0
+
             readStream.on("error", (err) => {
                 node.error(`readStream error: ${err.message}`);
             });
@@ -113,11 +118,8 @@ module.exports = function(RED) {
                 if (data == null) {
                     return;
                 }
-                if (msg.payload == null) {
-                    msg.payload = data;
-                } else {
-                    msg.payload = Buffer.concat([msg.payload, data]);
-                }
+                msg.payload.fill(data, pos, pos + data.length)
+                pos += data.length
             });
 
         } // readFile


### PR DESCRIPTION
I used `gcs-read` node to read a ~50MB file and it took several minutes to read the file stream. 
After carefully checking, I found the bottleneck was this line `msg.payload = Buffer.concat([msg.payload, data]);`.
Every time this line is invoked, it creates a new buffer and does memory copy.

In this PR, with the help of pre-allocating buffer and only copying small data chunk every time, the final total reading time became `< 10 seconds`.