### PR TITLE
Added config-in node

### DIFF
--- a/iot-config-in.html
+++ b/iot-config-in.html
@@ -1,0 +1,124 @@
+<!--
+Copyright 2020 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script type="text/html" data-template-name="google-cloud-iot config-in">
+    <!--Name-->
+<div class="form-row">
+    <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+    <input type="text" id="node-input-name">
+</div>
+
+<!--Project ID-->
+<div class="form-row">
+    <label for="node-input-projectId"><i class="fa fa-cloud"></i> Project ID</label>
+    <input type="text" id="node-input-projectId">
+</div>
+
+<!--Region-->
+<div class="form-row">
+    <label for="node-input-region"><i class="fa fa-globe"></i> Region</label>
+    <input type="text" id="node-input-region">
+</div>
+
+<!--Registry ID-->
+<div class="form-row">
+    <label for="node-input-registryId"><i class="fa fa-book"></i> Registry ID</label>
+    <input type="text" id="node-input-registryId">
+</div>
+
+<!--Device ID-->
+<div class="form-row">
+    <label for="node-input-deviceId"><i class="fa fa-microchip"></i> Device ID</label>
+    <input type="text" id="node-input-deviceId">
+</div>
+
+<!--Private Key-->
+<div class="form-row">
+    <label for="node-input-privateKey"><i class="fa fa-key"></i> Private Key</label>
+    <input type="text" id="node-input-privateKey">
+</div>
+
+<!--QoS-->
+<div class="form-row">
+    <label for="node-input-qos"><i class="fa fa-empire"></i>QoS</label>
+    <select id="node-input-qos" style="width:125px !important">
+        <option value="0">0</option>
+        <option value="1">1</option>
+    </select>
+</div>
+
+<!-- Assume JSON-->
+<div>
+    <label for="node-input-assumeJSON"><i class="fa fa-code"></i> Assume JSON&nbsp;
+        <input type="checkbox" id="node-input-assumeJSON" style="vertical-align: top;">
+    </label>
+</div>
+
+</script>
+
+<script type="text/html" data-help-name="google-cloud-iot config-in">
+    <p>Subscibe to config updates for a particular device</p>
+    <h3>Details</h3>
+
+    <p>
+        The GCP IoT Core allows one to receive configuration updates for a device from the Cloud.
+
+        In order to receive new config messages from the cloud, we need to identify that device. The properties to identify it are the combination of:
+
+        <ul>
+            <li><code>project id</code> - The project hosting the registry.</li>
+            <li><code>region</code> - The region in which the registry is defined.</li>
+            <li><code>registry id</code> - The identity of the registry.</li>
+            <li><code>device id</code> - The identity of the device.</li>
+            <li><code>qos</code> - (QoS) Quality of Service setting for the connection </li>
+        </ul>
+    </p>
+    <p>
+        The device must also authenticate itself and needs to be supplied a private key corresponding to the public key associated with the device in the registry.
+
+        The <code>msg.payload</code> field is the entire config object received from a particular device.
+    </p>
+    <p>
+        If we know that the incoming message contains a data payload that is JSON encoded, a configuration option called
+        <code>Assume JSON</code> can be selected.  When selected, the content of the message is parsed from a JSON string to an object
+        representation and stored at <code>msg.payload</code>.
+    </p>
+</script>
+
+<script type="text/javascript">
+    RED.nodes.registerType("google-cloud-iot config-in", {
+        "category": "GCP",
+        "defaults": {
+            "projectId": { "required": true },
+            "region": { "required": true },
+            "registryId": { "required": true },
+            "deviceId": { "required": true },
+            "name": { "value": "", "required": false },
+            "qos": { "value": 0, "required": true },
+            "assumeJSON": { value: false, required: false },
+            "privateKey": { "type": "google-cloud-private-key", "required": true }
+        },
+        "inputs": 0,
+        "outputs": 1,
+        "icon": "iot.png",
+        "align": "left",
+        "color": "#3FADB5",
+        "label": function () {
+            return this.name || this.topic || "iot config-in";
+        },
+        "paletteLabel": "iot config in"
+    });
+</script>

--- a/iot-config-in.js
+++ b/iot-config-in.js
@@ -1,0 +1,188 @@
+// Copyright 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Options:
+ * msg.payload
+ * msg.gcp.projectId
+ * msg.gcp.region
+ * msg.gcp.registryId
+ * msg.gcp.deviceId
+ */
+
+/* jshint esversion: 8 */
+module.exports = function (RED) {
+    "use strict";
+
+    const jwtExpMinutes = 24 * 60; // How long (in minutes) before the JWT token expires.
+    const jwt = require('jsonwebtoken');
+    const mqtt = require("mqtt");
+    //const utils = require('./utils.js');
+
+    function GoogleCloudIoTConfigIn(config) {
+        RED.nodes.createNode(this, config);
+
+        // When making a request to send a command to a device, the API requires the following values:
+        let projectId = null;
+        let region = null;
+        let registryId = null;
+        let deviceId = null;
+        //let subfolder  = null;
+        let privateKey = null;
+        let jwtRefreshTimeout = null;
+
+        let qos = null;
+
+        const STATUS_CONNECTED = {
+            fill: "green",
+            shape: "dot",
+            text: "connected"
+        };
+
+        const STATUS_DISCONNECTED = {
+            fill: "red",
+            shape: "dot",
+            text: "disconnected"
+        };
+
+        let mqttClient;  // The object representing the MQTT client.
+
+        const node = this;
+
+        // The following may be null values if not configured.
+        projectId = config.projectId;
+        region = config.region;
+        registryId = config.registryId;
+        deviceId = config.deviceId;
+        qos = Number(config.qos || 0);
+        //subfolder = config.subfolder;
+        //debugger;
+        //let xxx = RED.nodes.getNode(config.privateKey);
+        privateKey = RED.nodes.getNode(config.privateKey).credentials.privateKey;
+        // const transport = config.transport;  // Will be either MQTT or HTTP
+
+        // node.debug(`transport: ${transport}`);
+        //node.debug(`privateKey: ${privateKey}`);
+
+        // Disconnect from MQTT.
+        function mqttDisconnect() {
+            // If we have a jwtRefreshTimeout timer active then cancel it from firing.
+            if (!jwtRefreshTimeout) {
+                clearTimeout(jwtRefreshTimeout);
+                jwtRefreshTimeout = null;
+            }
+
+            // If we have an mqttClient, disconnect it.
+            if (mqttClient) {
+                mqttClient.end();
+                mqttClient = null;
+            }
+
+            node.status(STATUS_DISCONNECTED);
+        } // mqttDisconnect
+
+        // Called when mqtt message on config topic is received.  Registered with mqttClient.on('message') listener
+        function OnMessage(topic, message, packet) {
+            if (message === null) {
+                return;
+            }
+            const msg = {
+                "payload": message.toString(),    // Save the payload data at msg.payload
+                "packet": packet
+            }
+            if (config.assumeJSON === true) {
+                try {
+                    msg.payload = JSON.parse(RED.util.ensureString(message));
+                }
+                catch (err) {
+                    // We failed to parse the data ... log an error.
+                    node.error(`Failed to parse JSON: ${err}`);
+                }
+            }
+            node.send(msg);
+        } //OnMessage
+
+        // Called when the node is closed.  Here we want to disconnect the MQTT client if it is set.
+        function OnClose() {
+            mqttDisconnect();
+        } // OnClose
+
+        // Perform a connection to the MQTT bridge hosted by GCP.
+        function mqttConnnect() {
+            node.debug(">> mqttConnect");
+            mqttDisconnect(); // If we are already connected, disconnect.
+
+            // Form the MQTT connection to the IoT Core Bridge
+            const clientId = `projects/${projectId}/locations/${region}/registries/${registryId}/devices/${deviceId}`;
+            const connectionArgs = {
+                "host": "mqtt.googleapis.com",
+                "port": 8883,
+                "clientId": clientId,
+                "username": "unused",
+                "password": createJwt(projectId, privateKey, "RS256"),
+                "protocol": 'mqtts',
+                "protocolVersion": 4,
+                "clean": true,
+                "rejectUnauthorized": false
+            };
+
+            node.debug(`ClientId: ${clientId}`);
+            mqttClient = mqtt.connect(connectionArgs);  // Connect to the MQTT bridge
+            mqttClient.on("connect", (success) => {
+                node.status(STATUS_CONNECTED);
+                node.debug(`MQTT Connected: ${success}`);
+
+                // The connection has succeeded but the JWT token will expire after a period of time.  We setup a time
+                // that will fire before the expiration which will form a new connection.
+                const interval = (jwtExpMinutes - 1) * 60 * 1000;
+                jwtRefreshTimeout = setTimeout(function () {
+                    node.debug(">> Refresh JWT");
+                    mqttConnnect();
+                    node.debug("<< Refresh JWT");
+                }, interval);
+                node.debug(`Refresh in ${interval} msecs`);
+            });
+            mqttClient.on("error", (err) => {
+                node.debug(`MQTT Error: ${err}`);
+                mqttDisconnect();
+            });
+            node.debug("<< mqttConnect");
+        } // mqttConnnect
+
+
+        function createJwt(projectId, privateKey, algorithm) {
+            //node.log(`Creating JWT: projectId=${projectId}, algorithm=${algorithm}, privateKey=${privateKey}`);
+            const token = {
+                iat: parseInt(Date.now() / 1000),
+                exp: parseInt(Date.now() / 1000) + jwtExpMinutes * 60,
+                aud: projectId,
+            };
+            const jwtResult = jwt.sign(token, privateKey, { algorithm: algorithm });
+            //node.log(`<< Creating JWT`);
+            return jwtResult;
+        } // createJwt
+
+
+        // Form the MQTT connection to the IoT Core Bridge
+        node.status(STATUS_DISCONNECTED);
+        mqttConnnect();
+        mqttClient.subscribe(`/devices/${deviceId}/config`, { qos: qos });
+        mqttClient.on('message', OnMessage);
+        // If the transport is HTTP, nothing need be done.
+        node.on('close', OnClose);
+
+    } // GoogleCloudIoTConfigIn
+
+    RED.nodes.registerType("google-cloud-iot config-in", GoogleCloudIoTConfigIn);
+};

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
             "google-cloud-firestore": "firestore.js",
             "google-cloud-iot send-command": "iot-command-send.js",
             "google-cloud-iot config-update": "iot-config-update.js",
+            "google-cloud-iot config-in": "iot-config-in.js",
             "google-cloud-iot telemetry-send": "iot-telemetry-send.js",
             "google-cloud-automl": "automl.js",
             "google-cloud-text-to-speech": "text-to-speech.js",


### PR DESCRIPTION
Hi @kolban-google.

As discussed in #99, I was looking for a way to receive config objects from IoT Core. I added a node for this (mostly it just involved using parts of other nodes already existing in this repository.)

It is fully working for me, the only issue I see is that in future the telemetry-send node and this node should share a connection to the Google MQTT bridge. Presently if there are telemetry-send and config-in nodes on the same flow configured for the same device, both nodes periodically reconnect, causing the config-in node to repeatedly receive the newest config when it re-subscribes after reconnection, about every 20 seconds or so.

I propose a shared configuration node for all IoT Core related nodes to allow for a single persistent connection to the bridge.