### PR TITLE
Feature: GCE Instance Node - Basic Operations

### DIFF
--- a/examples/GCE_Instance.json
+++ b/examples/GCE_Instance.json
@@ -1,0 +1,523 @@
+[
+  {
+    "id": "015951b46535519c",
+    "type": "tab",
+    "label": "Flow - Scheduling Example",
+    "disabled": false,
+    "info": "",
+    "env": []
+  },
+  {
+    "id": "2b532bc030cb7f6d",
+    "type": "inject",
+    "z": "015951b46535519c",
+    "name": "start",
+    "props": [
+      {
+        "p": "payload"
+      },
+      {
+        "p": "topic",
+        "vt": "str"
+      }
+    ],
+    "repeat": "",
+    "crontab": "",
+    "once": false,
+    "onceDelay": 0.1,
+    "topic": "",
+    "payload": "",
+    "payloadType": "date",
+    "x": 230,
+    "y": 100,
+    "wires": [
+      [
+        "55434ecb6a3c587b"
+      ]
+    ]
+  },
+  {
+    "id": "55434ecb6a3c587b",
+    "type": "google-cloud-compute-engine-instance",
+    "z": "015951b46535519c",
+    "account": "",
+    "keyFilename": "",
+    "name": "List Instances",
+    "projectId": "my-project",
+    "zone": "us-central1-a",
+    "instance": "",
+    "operation": "list",
+    "template": "",
+    "x": 400,
+    "y": 100,
+    "wires": [
+      [
+        "e4907b54d98e1fed"
+      ]
+    ]
+  },
+  {
+    "id": "e4907b54d98e1fed",
+    "type": "split",
+    "z": "015951b46535519c",
+    "name": "for each",
+    "splt": "\\n",
+    "spltType": "str",
+    "arraySplt": 1,
+    "arraySpltType": "len",
+    "stream": false,
+    "addname": "",
+    "x": 580,
+    "y": 100,
+    "wires": [
+      [
+        "1049222ea688a36f"
+      ]
+    ]
+  },
+  {
+    "id": "ef20e05e55660db2",
+    "type": "switch",
+    "z": "015951b46535519c",
+    "name": "check status",
+    "property": "payload.status",
+    "propertyType": "msg",
+    "rules": [
+      {
+        "t": "eq",
+        "v": "RUNNING",
+        "vt": "str"
+      },
+      {
+        "t": "eq",
+        "v": "TERMINATED",
+        "vt": "str"
+      },
+      {
+        "t": "else"
+      }
+    ],
+    "checkall": "true",
+    "repair": false,
+    "outputs": 3,
+    "x": 310,
+    "y": 200,
+    "wires": [
+      [
+        "2553a892b293221c"
+      ],
+      [
+        "ff6db305d5306ad2"
+      ],
+      [
+        "7fc006ebc5792b76"
+      ]
+    ]
+  },
+  {
+    "id": "a82675c4a33692b0",
+    "type": "function",
+    "z": "015951b46535519c",
+    "name": "Handle Running",
+    "func": "const self = msg.payload.selfLink.split(\"/\")\n\nmsg.payload = {\n    projectId: self[6],\n    zone: self[8],\n    instance: self[10]\n}\n\nreturn msg;",
+    "outputs": 1,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 320,
+    "y": 300,
+    "wires": [
+      [
+        "71f19db2b96e3d87"
+      ]
+    ]
+  },
+  {
+    "id": "1049222ea688a36f",
+    "type": "link out",
+    "z": "015951b46535519c",
+    "name": "",
+    "mode": "link",
+    "links": [
+      "29f4ef94b3860270"
+    ],
+    "x": 695,
+    "y": 100,
+    "wires": []
+  },
+  {
+    "id": "29f4ef94b3860270",
+    "type": "link in",
+    "z": "015951b46535519c",
+    "name": "",
+    "links": [
+      "1049222ea688a36f",
+      "0f9e8118afd60b82"
+    ],
+    "x": 185,
+    "y": 200,
+    "wires": [
+      [
+        "ef20e05e55660db2"
+      ]
+    ]
+  },
+  {
+    "id": "2553a892b293221c",
+    "type": "link out",
+    "z": "015951b46535519c",
+    "name": "",
+    "mode": "link",
+    "links": [
+      "429314c3d6645736"
+    ],
+    "x": 455,
+    "y": 160,
+    "wires": []
+  },
+  {
+    "id": "429314c3d6645736",
+    "type": "link in",
+    "z": "015951b46535519c",
+    "name": "",
+    "links": [
+      "2553a892b293221c"
+    ],
+    "x": 185,
+    "y": 300,
+    "wires": [
+      [
+        "a82675c4a33692b0"
+      ]
+    ]
+  },
+  {
+    "id": "5a9f0d699d3ff714",
+    "type": "debug",
+    "z": "015951b46535519c",
+    "name": "Instance Stopped",
+    "active": true,
+    "tosidebar": true,
+    "console": false,
+    "tostatus": false,
+    "complete": "payload",
+    "targetType": "msg",
+    "statusVal": "",
+    "statusType": "auto",
+    "x": 730,
+    "y": 300,
+    "wires": []
+  },
+  {
+    "id": "71f19db2b96e3d87",
+    "type": "google-cloud-compute-engine-instance",
+    "z": "015951b46535519c",
+    "account": "",
+    "keyFilename": "",
+    "name": "Stop Instance",
+    "projectId": "",
+    "zone": "",
+    "instance": "",
+    "operation": "stop",
+    "template": "",
+    "x": 520,
+    "y": 300,
+    "wires": [
+      [
+        "5a9f0d699d3ff714"
+      ]
+    ]
+  },
+  {
+    "id": "ff6db305d5306ad2",
+    "type": "link out",
+    "z": "015951b46535519c",
+    "name": "",
+    "mode": "link",
+    "links": [
+      "3e7dcbe622403b02"
+    ],
+    "x": 455,
+    "y": 200,
+    "wires": []
+  },
+  {
+    "id": "7fc006ebc5792b76",
+    "type": "link out",
+    "z": "015951b46535519c",
+    "name": "",
+    "mode": "link",
+    "links": [
+      "a4d6254ca6358a18"
+    ],
+    "x": 455,
+    "y": 240,
+    "wires": []
+  },
+  {
+    "id": "44f9c0711f9f1e55",
+    "type": "comment",
+    "z": "015951b46535519c",
+    "name": "-> Stage 3a",
+    "info": "",
+    "x": 560,
+    "y": 160,
+    "wires": []
+  },
+  {
+    "id": "df132eb2f06291c1",
+    "type": "function",
+    "z": "015951b46535519c",
+    "name": "Handle Stopped",
+    "func": "const self = msg.payload.selfLink.split(\"/\")\n\nmsg.payload = {\n    projectId: self[6],\n    zone: self[8],\n    instance: self[10]\n}\n\nreturn msg;",
+    "outputs": 1,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 320,
+    "y": 360,
+    "wires": [
+      [
+        "3fb1e8d77156d4c9"
+      ]
+    ]
+  },
+  {
+    "id": "7e690a0d8bdb4a17",
+    "type": "debug",
+    "z": "015951b46535519c",
+    "name": "Instance Stopped",
+    "active": true,
+    "tosidebar": true,
+    "console": false,
+    "tostatus": false,
+    "complete": "payload",
+    "targetType": "msg",
+    "statusVal": "",
+    "statusType": "auto",
+    "x": 730,
+    "y": 360,
+    "wires": []
+  },
+  {
+    "id": "3fb1e8d77156d4c9",
+    "type": "google-cloud-compute-engine-instance",
+    "z": "015951b46535519c",
+    "account": "",
+    "keyFilename": "",
+    "name": "Start Instance",
+    "projectId": "",
+    "zone": "",
+    "instance": "",
+    "operation": "start",
+    "template": "",
+    "x": 520,
+    "y": 360,
+    "wires": [
+      [
+        "7e690a0d8bdb4a17"
+      ]
+    ]
+  },
+  {
+    "id": "b1ecfee8f5033f26",
+    "type": "function",
+    "z": "015951b46535519c",
+    "name": "Handle Other",
+    "func": "const self = msg.payload.selfLink.split(\"/\")\n\nmsg.payload = {\n    projectId: self[6],\n    zone: self[8],\n    instance: self[10]\n}\n\nreturn msg;",
+    "outputs": 1,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 310,
+    "y": 420,
+    "wires": [
+      [
+        "2f7fbe3344309c8e"
+      ]
+    ]
+  },
+  {
+    "id": "56e2707e816442c1",
+    "type": "google-cloud-compute-engine-instance",
+    "z": "015951b46535519c",
+    "account": "",
+    "keyFilename": "",
+    "name": "Get Instance",
+    "projectId": "",
+    "zone": "",
+    "instance": "",
+    "operation": "get",
+    "template": "",
+    "x": 630,
+    "y": 420,
+    "wires": [
+      [
+        "0f9e8118afd60b82"
+      ]
+    ]
+  },
+  {
+    "id": "2f7fbe3344309c8e",
+    "type": "delay",
+    "z": "015951b46535519c",
+    "name": "Wait",
+    "pauseType": "delay",
+    "timeout": "10",
+    "timeoutUnits": "seconds",
+    "rate": "1",
+    "nbRateUnits": "1",
+    "rateUnits": "second",
+    "randomFirst": "1",
+    "randomLast": "5",
+    "randomUnits": "seconds",
+    "drop": false,
+    "allowrate": false,
+    "outputs": 1,
+    "x": 470,
+    "y": 420,
+    "wires": [
+      [
+        "56e2707e816442c1"
+      ]
+    ]
+  },
+  {
+    "id": "3e7dcbe622403b02",
+    "type": "link in",
+    "z": "015951b46535519c",
+    "name": "",
+    "links": [
+      "ff6db305d5306ad2"
+    ],
+    "x": 185,
+    "y": 360,
+    "wires": [
+      [
+        "df132eb2f06291c1"
+      ]
+    ]
+  },
+  {
+    "id": "a4d6254ca6358a18",
+    "type": "link in",
+    "z": "015951b46535519c",
+    "name": "",
+    "links": [
+      "7fc006ebc5792b76"
+    ],
+    "x": 185,
+    "y": 420,
+    "wires": [
+      [
+        "b1ecfee8f5033f26"
+      ]
+    ]
+  },
+  {
+    "id": "71465d1468094d9b",
+    "type": "comment",
+    "z": "015951b46535519c",
+    "name": "Stage 1",
+    "info": "",
+    "x": 70,
+    "y": 100,
+    "wires": []
+  },
+  {
+    "id": "c613ec4c81c4b822",
+    "type": "comment",
+    "z": "015951b46535519c",
+    "name": "Stage 2",
+    "info": "",
+    "x": 70,
+    "y": 200,
+    "wires": []
+  },
+  {
+    "id": "183c3931ed332ad0",
+    "type": "comment",
+    "z": "015951b46535519c",
+    "name": "Stage 3a",
+    "info": "",
+    "x": 80,
+    "y": 300,
+    "wires": []
+  },
+  {
+    "id": "42adcba5e2be9426",
+    "type": "comment",
+    "z": "015951b46535519c",
+    "name": "Stage 3b",
+    "info": "",
+    "x": 80,
+    "y": 360,
+    "wires": []
+  },
+  {
+    "id": "891e7f6462ffa6d8",
+    "type": "comment",
+    "z": "015951b46535519c",
+    "name": "Stage 3c",
+    "info": "",
+    "x": 80,
+    "y": 420,
+    "wires": []
+  },
+  {
+    "id": "30e3a86e23ffbed8",
+    "type": "comment",
+    "z": "015951b46535519c",
+    "name": "-> Stage 2",
+    "info": "",
+    "x": 840,
+    "y": 420,
+    "wires": []
+  },
+  {
+    "id": "3985869ae09dbf48",
+    "type": "comment",
+    "z": "015951b46535519c",
+    "name": "-> Stage 3b",
+    "info": "",
+    "x": 560,
+    "y": 200,
+    "wires": []
+  },
+  {
+    "id": "0698e289bff8e234",
+    "type": "comment",
+    "z": "015951b46535519c",
+    "name": "-> Stage 3c",
+    "info": "",
+    "x": 560,
+    "y": 240,
+    "wires": []
+  },
+  {
+    "id": "0f9e8118afd60b82",
+    "type": "link out",
+    "z": "015951b46535519c",
+    "name": "",
+    "mode": "link",
+    "links": [
+      "29f4ef94b3860270"
+    ],
+    "x": 755,
+    "y": 420,
+    "wires": []
+  },
+  {
+    "id": "10ae5019c1b76bb4",
+    "type": "comment",
+    "z": "015951b46535519c",
+    "name": "Configure This Node ",
+    "info": "",
+    "x": 410,
+    "y": 60,
+    "wires": []
+  }
+]

--- a/gce-instance.html
+++ b/gce-instance.html
@@ -1,3 +1,20 @@
+<!--
+Copyright 2022 Google Inc.
+Created by Ari Victor
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 <script type="text/javascript">
     RED.nodes.registerType('google-cloud-compute-engine-instance', {
         category: 'GCP',

--- a/gce-instance.html
+++ b/gce-instance.html
@@ -1,0 +1,132 @@
+<script type="text/javascript">
+    RED.nodes.registerType('google-cloud-compute-engine-instance', {
+        category: 'GCP',
+        color: '#3FADB5',
+        defaults: {
+            account: { type: "google-cloud-credentials", required: false },
+            keyFilename: {value: "", required: false },
+            name: { value: "" },
+            projectId: { value: "" },
+            zone: { value: "" },
+            instance: { value: "" },
+            operation: { value: "" },
+            template: { value: "{}" },
+        },
+        inputs:1,
+        outputs:1,
+        icon: "font-awesome/fa-television",
+        label: function () {
+            return this.name || "gce-instance";
+        },
+        paletteLabel: "gce-instance",
+        oneditprepare: function() {
+            // Template JSON input
+            $("#node-input-template").typedInput({
+                type:"json",
+                types:["json"],
+            });
+        }
+    });
+</script>
+
+<script type="text/html" data-template-name="google-cloud-compute-engine-instance">
+    <!-- Node Name -->
+    <div class="form-row">
+        <label for="node-input-name">
+            <i class="fa fa-tag"></i> 
+            Node Name
+        </label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+
+    <hr>
+
+    <!-- Account -->
+    <div class="form-row">
+        <label for="node-input-account">
+            <i class="fa fa-user"></i> 
+            Credentials
+        </label>
+        <input type="text" id="node-input-account">
+    </div>
+
+    <!-- Key Filename -->
+    <div class="form-row">
+        <label for="node-input-keyFilename">
+            <i class="fa fa-user"></i> 
+            Key File
+        </label>
+        <input type="text" id="node-input-keyFilename">
+    </div>
+
+    <hr>
+
+    <!-- Operation -->
+    <div class="form-row">
+        <label for="node-input-operation">
+            Operation
+        </label>
+        <select id="node-input-operation">
+            <option value="get">get</option>
+            <option value="list">list</option>
+            <option value="start">start</option>
+            <option value="stop">stop</option>
+            <option value="reset">reset</option>
+            <option value="delete">delete</option>
+            <option value="create">create</option>
+        </select>
+    </div>
+
+    <hr>
+
+    <!-- Project ID -->
+    <div class="form-row">
+        <label for="node-input-projectId">
+            Project ID
+        </label>
+        <input type="text" id="node-input-projectId" placeholder="msg.payload.projectId">
+    </div>
+
+    <!-- Zone -->
+    <div class="form-row">
+        <label for="node-input-zone">
+            Zone
+        </label>
+        <input type="text" id="node-input-zone" placeholder="msg.payload.zone">
+    </div>
+
+    <!-- Instance Name -->
+    <div class="form-row">
+        <label for="node-input-instance">
+            Instance Name
+        </label>
+        <input type="text" id="node-input-instance" placeholder="msg.payload.instance">
+    </div>
+
+    <!-- Template -->
+    <div class="form-row">
+        <label for="node-input-template">
+            Instance Template
+        </label>
+        <input type="text" id="node-input-template" placeholder="msg.payload.template">
+    </div>
+
+</script>
+
+<!-- Documentation -->
+<script type="text/html" data-help-name="google-cloud-compute-engine-instance">
+    <p>A node for working with Cloud Compute Engine (GCP) instances</p>
+
+    <h3>Configuration</h3>
+    <p>
+        Properties can be explicitly set in the node. The node will also accept a dynamic payload object with the
+        set properties. Some operations will not require all properties to be configured.
+    </p>
+
+    <h3>Credentials</h3>
+    <p>
+        Credentials can be explicitly configured in the attached google-cloud-credentials node. If credentials are not specified the node will attempt 
+        to use any implicit GCP identity found in the Node Red environment. For local use we recommend setting your Application Default Credentials.
+    </p>
+</script>
+

--- a/gce-instance.js
+++ b/gce-instance.js
@@ -1,0 +1,186 @@
+/**
+ * Copyright 2022 Google Inc.
+ * Created by Ari Victor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This node GCE instance operations.  We will assume that msg.payload
+ * contains the the configuration required if not present in `config`.
+ */
+
+/* jshint esversion: 8 */
+module.exports = function (RED) {
+    "use strict";
+    const compute = require("@google-cloud/compute");
+    const NODE_TYPE = "google-cloud-compute-engine-instance";
+
+    function GCEInstanceNode(config) {
+
+        RED.nodes.createNode(this, config);
+        const node = this;
+
+        const Input = async (msg, send, done) => {
+
+            // Handle inputs
+            const account     = config.account ? config.account : msg.payload.account;
+            const instance    = config.instance ? config.instance : msg.payload.instance;
+            const keyFilename = config.keyFilename ? config.keyFilename : msg.payload.keyFilename
+            const operation   = config.operation ? config.operation : msg.payload.operation
+            const projectId   = config.projectId ? config.projectId : msg.payload.projectId
+            const template    = config.template ? config.template : msg.payload.template
+            const zone        = config.zone ? config.zone : msg.payload.zone
+
+            let credentials;
+            if (account) credentials = JSON.parse(RED.nodes.getCredentials(node).account);
+            const scopes = [
+                'https://www.googleapis.com/auth/cloud-platform',
+                'https://www.googleapis.com/auth/compute',
+            ]
+
+            let computeClient;
+            if (credentials) {
+                computeClient = new compute.InstancesClient({
+                    "projectId": projectId,
+                    "credentials": credentials,
+                    "scopes": scopes
+                });
+            } else if (keyFilename) {
+                computeClient = new compute.InstancesClient({
+                    "projectId": projectId,
+                    "keyFilename": keyFilename,
+                    "scopes": scopes
+                });
+            } else {
+                computeClient = new compute.InstancesClient({
+                    "projectId": projectId,
+                    "scopes": scopes
+                });
+            }
+
+            try {
+                /* Handle Get Instance */
+                if (operation === "get") {
+                    node.status({fill:"blue",shape:"dot",text:"getting instance"});
+                    await computeClient
+                        .get({
+                            instance: instance,
+                            project: projectId,
+                            zone: zone
+                        })
+                        .then(response => {
+                            msg.payload = response.length ? response[0] : {};
+                        });
+                }
+
+                /* Handle List Instances */
+                else if (operation === "list") {
+                    node.status({fill:"blue",shape:"dot",text:"listing instances"});
+                    await computeClient
+                        .list({
+                            project: projectId,
+                            zone: zone
+                        })
+                        .then(response => {
+                            msg.payload = response.length ? response[0] : [];
+                        });
+                }
+
+                /* Handle Stop Instance */
+                else if (operation === "stop") {
+                    node.status({fill:"blue",shape:"dot",text:"stopping instance"});
+                    await computeClient
+                        .stop({
+                            instance: instance,
+                            project: projectId,
+                            zone: zone
+                        })
+                        .then(response => {
+                            msg.payload = response.length ? response[0] : {};
+                        });
+                }
+
+                /* Handle Start Instance */
+                else if (operation === "start") {
+                    node.status({fill:"blue",shape:"dot",text:"starting instance"});
+                    await computeClient
+                        .start({
+                            instance: instance,
+                            project: projectId,
+                            zone: zone
+                        })
+                        .then(response => {
+                            msg.payload = response.length ? response[0] : {};
+                        });
+                }
+
+                /* Handle Reset Instance */
+                else if (operation === "reset") {
+                    node.status({fill:"blue",shape:"dot",text:"resetting instance"});
+                    await computeClient
+                        .reset({
+                            instance: instance,
+                            project: projectId,
+                            zone: zone
+                        })
+                        .then(response => {
+                            msg.payload = response.length ? response[0] : {};
+                        });
+                }
+
+                /* Handle Delete Instance */
+                else if (operation === "delete") {
+                    node.status({fill:"blue",shape:"dot",text:"deleting instance"});
+                    await computeClient
+                        .delete({
+                            instance: instance,
+                            project: projectId,
+                            zone: zone
+                        })
+                        .then(response => {
+                            msg.payload = response.length ? response[0] : {};
+                        });
+                }
+
+                /* Handle Create Instance */
+                else if (operation === "create") {
+                    node.status({fill:"blue",shape:"dot",text:"creating instance"});
+                    await computeClient
+                        .insert({
+                            project: projectId,
+                            zone: zone,
+                            instanceResource: typeof template === "string" ? JSON.parse(template) : template
+                        })
+                        .then(response => {
+                            msg.payload = response.length ? response[0] : {};
+                        });
+                }
+                node.status({fill:"green",shape:"dot",text:"complete"});
+                node.send(msg);
+            }
+            catch (error) {
+                node.status({fill:"red",shape:"dot",text:"error"});
+                if (done) {
+                    done(error);
+                } else {
+                    node.err(error, msg);
+                }
+            }
+        }
+
+        const Close = () => { };
+
+        node.on("input", Input);
+        node.on("close", Close);
+    }
+    RED.nodes.registerType(NODE_TYPE, GCEInstanceNode);
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "dependencies": {
         "@google-cloud/automl": "latest",
         "@google-cloud/bigquery": "latest",
+        "@google-cloud/compute": "^3.1.1",
         "@google-cloud/dlp": "latest",
         "@google-cloud/dns": "latest",
         "@google-cloud/documentai": "latest",
@@ -41,7 +42,8 @@
         "translate",
         "BigQuery",
         "Firestore",
-        "iot"
+        "iot",
+        "compute"
     ],
     "node-red": {
         "nodes": {
@@ -72,7 +74,8 @@
             "google-cloud-automl": "automl.js",
             "google-cloud-text-to-speech": "text-to-speech.js",
             "google-cloud-documentai": "documentai.js",
-            "google-cloud-spanner": "spanner.js"
+            "google-cloud-spanner": "spanner.js",
+            "google-cloud-compute-engine-instance": "gce-instance.js"
         }
     },
     "scripts": {


### PR DESCRIPTION
Hi All,

I've made an attempt at creating a GCE Instance node for performing basic operations:

- List instances
- Get Instance
- Start Instance
- Stop Instance
- Reset Instance
- Delete Instance
- Create Instance

The node can be configured explicitly via the node UI or it can be dynamically configured via a previous node using `msg.payload`.

```javascript
msg.payload = {
    projectId: "string", // GCP project ID
    zone: "string", // instance zone e.g. us-central1-a
    instance: "string", // instance name
    operation: "string", // get, list, start, stop, reset, delete, create
    template: "JSON String or Object", // as per https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert#request-body
}
```

The node outputs the direct response from GCP into `msg.payload`.

There is an included example flow that shows a use case for scheduling the start and stop of instances. After feedback, critique, and if I should continue with this node. I'm hoping to continue adding features and other operations as well as help develop other GCE based nodes (disk, snapshots, etc).

Thanks,
Ari

<img width="739" alt="example2" src="https://user-images.githubusercontent.com/11803028/151675817-deccb41b-b9ca-42ea-8af9-0ef0ea7853a1.png">

<img width="918" alt="example1" src="https://user-images.githubusercontent.com/11803028/151675819-0ab7763d-7922-4ec0-a213-940307a843c2.png">

