### PR TITLE
Add Document ID to response

### DIFF
--- a/firestore.js
+++ b/firestore.js
@@ -131,7 +131,7 @@ module.exports = function(RED) {
                     const querySnapshot = await query.get();
                     let results = [];
                     querySnapshot.forEach((queryDocumentSnapshot) => {
-                        results.push(queryDocumentSnapshot.data());
+                        results.push({id:queryDocumentSnapshot.id,data:queryDocumentSnapshot.data()});
                     });
                     msg.payload = results;
 


### PR DESCRIPTION
When doing any updates and changes we'd need a document id returned from a query, this would change the message structure but would honour the id/data structure of the API.